### PR TITLE
Allow --userconfig to be passed through unchanged

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ module.exports = envpm
 function envpm (dir, args, _exec, check) {
   var execNpm = _exec || exec
 
+  if (args.indexOf('--userconfig') > -1) {
+    return execNpm(args)
+  }
+
   findFile('.npmrc', dir, runNpm)
 
   function runNpm (err, found) {

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,28 @@ test('finds file in dir', function (t) {
   }
 })
 
+test('passes through already-set userconfig', function (t) {
+  t.plan(1)
+
+  envpm(
+    path.join(__dirname, 'test-dir1'),
+    ['--userconfig', 'beep', 'install', 'butts@0.0.0'],
+    checkExec
+  )
+
+  function checkExec (args) {
+    t.deepEqual(
+      args,
+      [
+        '--userconfig',
+        'beep',
+        'install',
+        'butts@0.0.0'
+      ]
+    )
+  }
+})
+
 test('lists found location for `which`', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
In instances where a user specifies a `--userconfig`, it'd be nice to pass this through rather than eating it.